### PR TITLE
This branch was meant to be named 'create-verb-form-model'.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,8 @@ gem 'rake'
 
 gem 'shotgun'
 
+gem 'pry'
+
 group :test do
   gem 'database_cleaner', '~> 1.4.1'
   gem 'shoulda-matchers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    coderay (1.1.1)
     database_cleaner (1.4.1)
     diff-lcs (1.2.5)
     factory_girl (4.7.0)
@@ -36,6 +37,7 @@ GEM
       i18n (~> 0.5)
     i18n (0.7.0)
     json (1.8.3)
+    method_source (0.8.2)
     mime-types (3.0)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0221)
@@ -45,6 +47,10 @@ GEM
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
     pg (0.18.4)
+    pry (0.10.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     rack (1.6.4)
     rack-protection (1.5.3)
       rack
@@ -79,6 +85,7 @@ GEM
       rack-test
       sinatra (~> 1.4.0)
       tilt (>= 1.3, < 3)
+    slop (3.6.0)
     thread_safe (0.3.5)
     tilt (2.0.4)
     tzinfo (1.2.2)
@@ -98,6 +105,7 @@ DEPENDENCIES
   factory_girl
   faker
   pg
+  pry
   rack-test
   rake
   rspec

--- a/Rakefile
+++ b/Rakefile
@@ -128,7 +128,7 @@ end
 
 desc 'Start IRB with application environment loaded'
 task "console" do
-  exec "irb -r./config/environment"
+  exec "pry -r./config/environment"
 end
 
 task :default  => :spec

--- a/app/models/verb_form.rb
+++ b/app/models/verb_form.rb
@@ -1,0 +1,3 @@
+class VerbForm < ActiveRecord::Base
+  # Remember to create a migration!
+end

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -20,6 +20,8 @@ require "sinatra/reloader" if development?
 
 require 'erb'
 
+require 'pry'
+
 # Some helper constants for path-centric logic
 APP_ROOT = Pathname.new(File.expand_path('../../', __FILE__))
 

--- a/db/migrate/20160519183221_create_verb_forms.rb
+++ b/db/migrate/20160519183221_create_verb_forms.rb
@@ -9,7 +9,7 @@ class CreateVerbForms < ActiveRecord::Migration
   		t.string :mood
   		t.string :voice
   		t.string :non_finite_cat
-  		t.string :verb_form, null: false
+  		t.string :form, null: false
 
   		t.timestamps null: false
   	end


### PR DESCRIPTION
Created model VerbForm for verb_form table, and tested model in console.
Changed default ruby interpreter from irb to pry.
Corrected name of column from 'verb_form' to 'form'
